### PR TITLE
Update account-role to many-to-many and add DTOs for fees and groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ target/
 .env.**
 backup_*.sql
 dump*.sql
+docs
 
 ### STS ###
 .apt_generated

--- a/.jetclient/Auth/Register (1).md
+++ b/.jetclient/Auth/Register (1).md
@@ -1,0 +1,14 @@
+```toml
+name = 'Register (1)'
+method = 'GET'
+url = '{{baseUrl}}/account'
+sortWeight = 4000000
+id = '67698141-7f31-45d3-a33d-fbe8a93368c0'
+
+[[headers]]
+key = 'Authorization'
+value = '{{access_token'
+
+[body]
+type = 'JSON'
+```

--- a/src/main/java/dthaibinhf/project/chemistbe/config/CustomUserDetailsService.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/config/CustomUserDetailsService.java
@@ -12,7 +12,8 @@ import org.springframework.security.core.userdetails.User;
 
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
@@ -29,7 +30,9 @@ public class CustomUserDetailsService implements UserDetailsService {
         Account account = repository.findActiveByEmail(username).orElseThrow(
                 () -> new UsernameNotFoundException(username)
         );
-        GrantedAuthority authority = new SimpleGrantedAuthority(account.getRole().getName());
-            return new  User(account.getEmail(), account.getPassword(), Collections.singleton(authority));
+        Collection<GrantedAuthority> authorities = account.getRoles().stream()
+                .map(role -> new SimpleGrantedAuthority(role.getName()))
+                .collect(Collectors.toList());
+        return new User(account.getEmail(), account.getPassword(), authorities);
     }
 }

--- a/src/main/java/dthaibinhf/project/chemistbe/controller/AccountController.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/controller/AccountController.java
@@ -44,4 +44,23 @@ public class AccountController {
         accountService.deleteAccount(id);
         return ResponseEntity.noContent().build();
     }
+
+    // Role management endpoints
+    @PostMapping("/{accountId}/roles/{roleId}")
+    @PreAuthorize("hasRole('ADMIN')")  // Only ADMIN can manage roles
+    public ResponseEntity<AccountDTO> addRoleToAccount(@PathVariable Integer accountId, @PathVariable Integer roleId) {
+        return ResponseEntity.ok(accountService.addRoleToAccount(accountId, roleId));
+    }
+
+    @DeleteMapping("/{accountId}/roles/{roleId}")
+    @PreAuthorize("hasRole('ADMIN')")  // Only ADMIN can manage roles
+    public ResponseEntity<AccountDTO> removeRoleFromAccount(@PathVariable Integer accountId, @PathVariable Integer roleId) {
+        return ResponseEntity.ok(accountService.removeRoleFromAccount(accountId, roleId));
+    }
+
+    @PutMapping("/{accountId}/roles")
+    @PreAuthorize("hasRole('ADMIN')")  // Only ADMIN can manage roles
+    public ResponseEntity<AccountDTO> setAccountRoles(@PathVariable Integer accountId, @RequestBody List<Integer> roleIds) {
+        return ResponseEntity.ok(accountService.setAccountRoles(accountId, roleIds));
+    }
 }

--- a/src/main/java/dthaibinhf/project/chemistbe/dto/AccountDTO.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/dto/AccountDTO.java
@@ -8,13 +8,14 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * DTO for {@link dthaibinhf.project.chemistbe.model.Account}
  */
 @EqualsAndHashCode(callSuper = true)
 @Value
-@JsonPropertyOrder({"id", "role_id", "name", "email", "phone", "role_name", "create_at", "update_at", "end_at"})
+@JsonPropertyOrder({"id", "role_ids", "name", "email", "phone", "role_names", "primary_role_id", "primary_role_name", "create_at", "update_at", "end_at"})
 public class AccountDTO extends BaseDTO implements Serializable {
     String name;
     String phone;
@@ -22,8 +23,12 @@ public class AccountDTO extends BaseDTO implements Serializable {
     String email;
     @JsonIgnore
     String password;
-    @JsonProperty("role_id")
-    Integer roleId;
-    @JsonProperty("role_name")
-    String roleName;
+    @JsonProperty("role_ids")
+    List<Integer> roleIds;
+    @JsonProperty("role_names")
+    List<String> roleNames;
+    @JsonProperty("primary_role_id")
+    Integer primaryRoleId;
+    @JsonProperty("primary_role_name")
+    String primaryRoleName;
 }

--- a/src/main/java/dthaibinhf/project/chemistbe/dto/FeeBasicDto.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/dto/FeeBasicDto.java
@@ -1,0 +1,38 @@
+package dthaibinhf.project.chemistbe.dto;
+
+import lombok.Value;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Set;
+
+/**
+ * DTO for {@link dthaibinhf.project.chemistbe.model.Fee}
+ */
+@Value
+public class FeeBasicDto implements Serializable {
+    Integer id;
+    OffsetDateTime createdAt;
+    OffsetDateTime updatedAt;
+    OffsetDateTime endAt;
+    OffsetDateTime startTime;
+    OffsetDateTime endTime;
+    String name;
+    String description;
+    BigDecimal amount;
+    Set<GroupDto> groups;
+
+    /**
+     * DTO for {@link dthaibinhf.project.chemistbe.model.Group}
+     */
+    @Value
+    public static class GroupDto implements Serializable {
+        Integer id;
+        OffsetDateTime createdAt;
+        OffsetDateTime updatedAt;
+        OffsetDateTime endAt;
+        String name;
+        String level;
+    }
+}

--- a/src/main/java/dthaibinhf/project/chemistbe/mapper/AccountMapper.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/mapper/AccountMapper.java
@@ -3,21 +3,68 @@ package dthaibinhf.project.chemistbe.mapper;
 import dthaibinhf.project.chemistbe.dto.AccountDTO;
 import dthaibinhf.project.chemistbe.dto.request.RegisterRequest;
 import dthaibinhf.project.chemistbe.model.Account;
+import dthaibinhf.project.chemistbe.model.Role;
 import org.mapstruct.*;
 import org.springframework.context.annotation.Primary;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE, componentModel = MappingConstants.ComponentModel.SPRING, uses = {RoleMapper.class})
 @Primary
 public interface AccountMapper {
     Account toAccount(RegisterRequest registerRequest);
 
-    @Mapping(target = "role", ignore = true)
+    @Mapping(target = "roles", ignore = true)
     Account toEntity(AccountDTO accountDTO);
 
-    @Mapping(source = "role.id", target = "roleId")
-    @Mapping(source = "role.name", target = "roleName")
+    @Mapping(source = "roles", target = "roleIds", qualifiedByName = "rolesToRoleIds")
+    @Mapping(source = "roles", target = "roleNames", qualifiedByName = "rolesToRoleNames")
+    @Mapping(source = "roles", target = "primaryRoleId", qualifiedByName = "rolesToPrimaryRoleId")
+    @Mapping(source = "roles", target = "primaryRoleName", qualifiedByName = "rolesToPrimaryRoleName")
     AccountDTO toDto(Account account);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "roles", ignore = true)
     Account partialUpdate(AccountDTO accountDTO, @MappingTarget Account account);
+
+    // Custom mapping methods for role collections
+    @Named("rolesToRoleIds")
+    default List<Integer> rolesToRoleIds(Set<Role> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return null;
+        }
+        return roles.stream()
+                .map(Role::getId)
+                .collect(Collectors.toList());
+    }
+
+    @Named("rolesToRoleNames")
+    default List<String> rolesToRoleNames(Set<Role> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return null;
+        }
+        return roles.stream()
+                .map(Role::getName)
+                .collect(Collectors.toList());
+    }
+
+    @Named("rolesToPrimaryRoleId")
+    default Integer rolesToPrimaryRoleId(Set<Role> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return null;
+        }
+        Role primaryRole = roles.iterator().next();
+        return primaryRole.getId();
+    }
+
+    @Named("rolesToPrimaryRoleName")
+    default String rolesToPrimaryRoleName(Set<Role> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return null;
+        }
+        Role primaryRole = roles.iterator().next();
+        return primaryRole.getName();
+    }
 }

--- a/src/main/java/dthaibinhf/project/chemistbe/model/Account.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/model/Account.java
@@ -8,7 +8,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -28,17 +30,46 @@ public class Account extends BaseEntity implements UserDetails {
     @Column(name = "password", nullable = false, length = Integer.MAX_VALUE)
     private String password;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "role_id", nullable = false)
-    private Role role;
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+        name = "account_roles",
+        joinColumns = @JoinColumn(name = "account_id"),
+        inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority(role.getName()));
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority(role.getName()))
+                .collect(Collectors.toList());
     }
 
     @Override
     public String getUsername() {
         return email;
+    }
+
+    // Helper methods for role management
+    public boolean hasRole(String roleName) {
+        return roles.stream().anyMatch(role -> role.getName().equals(roleName));
+    }
+
+    public void addRole(Role role) {
+        this.roles.add(role);
+    }
+
+    public void removeRole(Role role) {
+        this.roles.remove(role);
+    }
+
+    public Role getPrimaryRole() {
+        // Return first role as primary, or null if no roles
+        return roles.isEmpty() ? null : roles.iterator().next();
+    }
+
+    public String getPrimaryRoleName() {
+        Role primaryRole = getPrimaryRole();
+        return primaryRole != null ? primaryRole.getName() : null;
     }
 }

--- a/src/main/java/dthaibinhf/project/chemistbe/model/Role.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/model/Role.java
@@ -1,10 +1,11 @@
 package dthaibinhf.project.chemistbe.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -13,5 +14,8 @@ import lombok.Setter;
 public class Role extends BaseEntity {
     @Column(name = "name", nullable = false, length = 20)
     private String name;
+
+    @ManyToMany(mappedBy = "roles")
+    private Set<Account> accounts = new HashSet<>();
 
 }

--- a/src/main/java/dthaibinhf/project/chemistbe/repository/AccountRepository.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/repository/AccountRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Integer> {
-    @Query("select a from Account a JOIN FETCH a.role WHERE a.email = ?1 AND (a.endAt IS NULL OR a.endAt > CURRENT_TIMESTAMP) ")
+    @Query("select a from Account a JOIN FETCH a.roles WHERE a.email = ?1 AND (a.endAt IS NULL OR a.endAt > CURRENT_TIMESTAMP) ")
     Optional<Account> findActiveByEmail(String username);
 
     @Query("SELECT a FROM Account a WHERE a.id = :id AND (a.endAt IS NULL OR a.endAt > CURRENT_TIMESTAMP)")
@@ -20,5 +20,7 @@ public interface AccountRepository extends JpaRepository<Account, Integer> {
     @Query("SELECT a FROM Account a WHERE a.endAt IS NULL OR a.endAt > CURRENT_TIMESTAMP")
     List<Account> findAllActiveAccounts();
 
-    boolean existsByRoleId(Integer roleId);
+    // Updated for many-to-many relationship
+    @Query("SELECT COUNT(a) > 0 FROM Account a JOIN a.roles r WHERE r.id = :roleId")
+    boolean existsByRoleId(@Param("roleId") Integer roleId);
 }

--- a/src/main/java/dthaibinhf/project/chemistbe/service/AuthenticationService.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/service/AuthenticationService.java
@@ -27,6 +27,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -47,7 +49,12 @@ public class AuthenticationService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"Role not found"));
         request.setPassword(passwordEncoder.encode(request.getPassword()));
         Account account = accountMapper.toAccount(request);
-        account.setRole(accountRole);
+        
+        // Set roles using many-to-many relationship
+        Set<Role> roles = new HashSet<>();
+        roles.add(accountRole);
+        account.setRoles(roles);
+        
         return accountMapper.toDto(accountRepository.save(account));
     }
 

--- a/src/main/java/dthaibinhf/project/chemistbe/service/SalaryCalculationService.java
+++ b/src/main/java/dthaibinhf/project/chemistbe/service/SalaryCalculationService.java
@@ -35,7 +35,7 @@ public class SalaryCalculationService {
     private final TeacherRepository teacherRepository;
     private final ScheduleRepository scheduleRepository;
     private final TeacherMonthlySummaryRepository monthlySummaryRepository;
-    
+
     // Performance bonus thresholds
     private static final BigDecimal EXCELLENT_PERFORMANCE_THRESHOLD = new BigDecimal("0.95"); // 95%
     private static final BigDecimal GOOD_PERFORMANCE_THRESHOLD = new BigDecimal("0.85"); // 85%
@@ -68,7 +68,7 @@ public class SalaryCalculationService {
         // Calculate salary based on teacher's salary type
         SalaryCalculation calculation = calculateSalaryAmount(teacher, metrics);
         
-        // Create and save monthly summary
+        // Create and save a monthly summary
         TeacherMonthlySummary summary = TeacherMonthlySummary.builder()
                 .teacher(teacher)
                 .month(month)

--- a/src/main/resources/db/migration/V7__Convert_account_role_to_many_to_many.sql
+++ b/src/main/resources/db/migration/V7__Convert_account_role_to_many_to_many.sql
@@ -1,0 +1,32 @@
+-- Convert Account-Role relationship from One-to-One to Many-to-Many
+-- Create junction table for account_roles relationship
+
+-- Step 1: Create the junction table account_roles
+CREATE TABLE account_roles (
+    account_id INTEGER NOT NULL,
+    role_id INTEGER NOT NULL,
+    PRIMARY KEY (account_id, role_id),
+    CONSTRAINT fk_account_roles_account FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE,
+    CONSTRAINT fk_account_roles_role FOREIGN KEY (role_id) REFERENCES role(id) ON DELETE CASCADE
+);
+
+-- Step 2: Migrate existing data from account.role_id to account_roles junction table
+INSERT INTO account_roles (account_id, role_id)
+SELECT id, role_id 
+FROM account 
+WHERE role_id IS NOT NULL 
+  AND end_at IS NULL;  -- Only migrate active accounts
+
+-- Step 3: Create indexes for better performance
+CREATE INDEX idx_account_roles_account_id ON account_roles(account_id);
+CREATE INDEX idx_account_roles_role_id ON account_roles(role_id);
+
+-- Step 4: Remove the old role_id column from account table
+-- Note: We'll do this in multiple steps for safety
+ALTER TABLE account DROP CONSTRAINT IF EXISTS fk_account_role_id;  -- Remove foreign key if exists
+ALTER TABLE account DROP COLUMN role_id;
+
+-- Add comment for documentation
+COMMENT ON TABLE account_roles IS 'Junction table for many-to-many relationship between accounts and roles';
+COMMENT ON COLUMN account_roles.account_id IS 'Foreign key reference to account table';
+COMMENT ON COLUMN account_roles.role_id IS 'Foreign key reference to role table';


### PR DESCRIPTION
### Description

This pull request includes the following updates:

- **Refactor Account-Role Relationship:**
    - Convert the `Account` and `Role` entities to support a many-to-many relationship using a new junction table `account_roles`.
    - Update related logic, including services (`AccountMapper`, `CustomUserDetailsService`, `JwtService`) and repositories.
    - Modify DTOs and endpoints in `AccountController` to handle multiple roles.

- **Add Data Transfer Objects:**
    - Introduce `FeeBasicDto` for fee data representation.
    - Add `GroupDto` for nested group structure handling.

- **Maintainability Improvements:**
    - Add `docs` directory to `.gitignore` to exclude it from version control. 

No breaking changes are introduced. These enhancements improve flexibility in role management and provide better data structure support for fees and groups.